### PR TITLE
Refactor/create_custom_hook

### DIFF
--- a/frontend/app/FeedScreen.tsx
+++ b/frontend/app/FeedScreen.tsx
@@ -1,60 +1,20 @@
-import { FeedItem, fetchFeed } from '@/api/feed'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { FeedItem } from '@/api/feed'
+import { useCallback, useMemo, useRef } from 'react'
 import { Dimensions, FlatList, RefreshControl, ViewToken } from 'react-native'
 import VideoCell from './VideoCell'
+import { useFeed } from '@/hooks/useFeed'
 
 const { height: SCREEN_H } = Dimensions.get('window')
 
 const FeedScreen = () => {
-  const [items, setItems] = useState<FeedItem[]>([])
-  const [nextCursor, setNextCursor] = useState<string | null>(null)
-  const [activeItemId, setActiveItemId] = useState<string | null>(null)
-  const [loadingMore, setLoadingMore] = useState(false)
-  const [refreshing, setRefreshing] = useState(false)
-
-  const loadFirst = useCallback(async () => {
-    setRefreshing(true)
-
-    try {
-      const res = await fetchFeed({
-        cursor: null,
-        limit: 10,
-      })
-
-      setItems(res.items)
-      setNextCursor(res.nextCursor)
-      setActiveItemId(res.items[0]?.id ?? '')
-    } finally {
-      setRefreshing(false)
-    }
-  }, [])
-
-  const loadMore = useCallback(async () => {
-    if (loadingMore || !nextCursor) return
-
-    setLoadingMore(true)
-
-    try {
-      const res = await fetchFeed({
-        cursor: nextCursor,
-        limit: 10,
-      })
-
-      setItems((prev) => {
-        const seen = new Set(prev.map((x) => x.id))
-        const add = res.items.filter((x) => !seen.has(x.id))
-        return [...prev, ...add]
-      })
-      setNextCursor(res.nextCursor)
-    } finally {
-      setLoadingMore(false)
-    }
-  }, [loadingMore, nextCursor])
-
-  // Load first page on mount
-  useEffect(() => {
-    void loadFirst()
-  }, [loadFirst])
+  const {
+    items,
+    activeItemId,
+    setActiveItemId,
+    refreshing,
+    loadFirst,
+    loadMore,
+  } = useFeed()
 
   // ビデオがほぼ全画面になったらアクティブとみなす
   const viewabilityConfig = useMemo(

--- a/frontend/hooks/useFeed.ts
+++ b/frontend/hooks/useFeed.ts
@@ -1,0 +1,63 @@
+import { FeedItem, fetchFeed } from '@/api/feed'
+import { useCallback, useEffect, useState } from 'react'
+
+export const useFeed = () => {
+  const [items, setItems] = useState<FeedItem[]>([])
+  const [nextCursor, setNextCursor] = useState<string | null>(null)
+  const [activeItemId, setActiveItemId] = useState<string | null>(null)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [refreshing, setRefreshing] = useState(false)
+
+  const loadFirst = useCallback(async () => {
+    setRefreshing(true)
+
+    try {
+      const res = await fetchFeed({
+        cursor: null,
+        limit: 10,
+      })
+
+      setItems(res.items)
+      setNextCursor(res.nextCursor)
+      setActiveItemId(res.items[0]?.id ?? '')
+    } finally {
+      setRefreshing(false)
+    }
+  }, [])
+
+  const loadMore = useCallback(async () => {
+    if (loadingMore || !nextCursor) return
+
+    setLoadingMore(true)
+
+    try {
+      const res = await fetchFeed({
+        cursor: nextCursor,
+        limit: 10,
+      })
+
+      setItems((prev) => {
+        const seen = new Set(prev.map((x) => x.id))
+        const add = res.items.filter((x) => !seen.has(x.id))
+        return [...prev, ...add]
+      })
+      setNextCursor(res.nextCursor)
+    } finally {
+      setLoadingMore(false)
+    }
+  }, [loadingMore, nextCursor])
+
+  // Load first page on mount
+  useEffect(() => {
+    void loadFirst()
+  }, [loadFirst])
+
+  return {
+    items,
+    activeItemId,
+    setActiveItemId,
+    refreshing,
+    loadFirst,
+    loadMore,
+  }
+}


### PR DESCRIPTION
- `FeedScreen` コンポーネントにて、feed部分は他のコンポーネントでも利用する予定（例えば、特定のワードでの動画検索結果など）であり、これらのロジックはUIコンポーネントの責務ではないので、 `useFeed` として責務分離
  - `viewabilityConfig` なども分けられそうであるが、今は規模が小さく、そこまで細かく分けなくても良いと判断したのでそのまま（このUI固有ではあるので）